### PR TITLE
Updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ npm install
 Start development server
 
 ```shell
-cd src
-vue serve
+npm run serve
 ```
 
 The app should be running at http://localhost:8080/


### PR DESCRIPTION
Original command 'vue serve' requires a global addon @vue/cli-service-global to be installed. Changed the command to 'npm run serve' instead