### PR TITLE
Fixed exception displayed on console after loading any valid json file

### DIFF
--- a/src/components/HomePage.vue
+++ b/src/components/HomePage.vue
@@ -73,12 +73,13 @@ export default {
   },
   methods: {
     uploadStatus: function() {
-      this.fileUploaded = true;
+      //this.fileUploaded = true;
     },
     readFile: function() {
       var reader = new FileReader();
       reader.onload = function(event) {
         this.json = JSON.parse(event.target.result);
+        this.fileUploaded = true;
       }.bind(this);
       reader.readAsText(this.file);
     }

--- a/src/components/HomePage.vue
+++ b/src/components/HomePage.vue
@@ -31,7 +31,7 @@
         ></b-form-file>
       </div>
       <br>
-      <b-button :size="''" :variant="'primary'" v-on:click="uploadStatus(), readFile()">Upload</b-button>
+      <b-button :size="''" :variant="'primary'" v-on:click="readFile()">Upload</b-button>
     </div>
   </div>
 </template>
@@ -72,9 +72,6 @@ export default {
     };
   },
   methods: {
-    uploadStatus: function() {
-      //this.fileUploaded = true;
-    },
     readFile: function() {
       var reader = new FileReader();
       reader.onload = function(event) {


### PR DESCRIPTION
In HomePage.vue, _fileUploaded_ variable was being set to True in the the
**_uploadStatus(_**) method which triggers the _AnnotationsPage_ component and
which expects json document in the json variable. Since the actual json
document gets loaded only after readFile() method, code throws an
exception in the background. While it does not impact the functionality
of application, it's still an irritating exception to have in the
console. With this fix, i am now marking this flag as True within the
**_readFile()_** method.