### PR TITLE
Fixed linting issue

### DIFF
--- a/src/components/AnnotationsPage.vue
+++ b/src/components/AnnotationsPage.vue
@@ -164,7 +164,7 @@ export default {
       ];
       paragraph_container.qas.splice(row_index, 1);
     },
-    getSelection: function(fixStr, allStr) {
+    getSelection: function(fixStr) {
       this.answer = fixStr;
     },
     delete_paragraph: function() {


### PR DESCRIPTION
_getSelection(fixStr, **allStr**)_ function accepts two parameters but does not uses the second parameter which gives a linting error. Fixed code by removing the passed parameter